### PR TITLE
use `gp_camera_unref` instead of `gp_camera_free`

### DIFF
--- a/gphoto2cffi/gphoto2.py
+++ b/gphoto2cffi/gphoto2.py
@@ -852,4 +852,4 @@ class Camera(object):
     def __del__(self):
         if self.__cam is not None:
             lib.gp_camera_exit(self.__cam, self._ctx)
-            lib.gp_camera_free(self.__cam)
+            lib.gp_camera_unref(self.__cam)


### PR DESCRIPTION
Use `gp_camera_unref` (http://www.gphoto.org/doc/api/gphoto2-camera_8c.html#a6027cb54859c035ce943cf1c3e06121a) instead of `gp_camera_free` (http://www.gphoto.org/doc/api/gphoto2-camera_8c.html#a78ae1a19cc0fb4d94026f82497381124) as the latter is deprecated.