### PR TITLE
Fixup incorrect code snippet

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ offering access to most of the library's features.
 
 .. code:: python
 
-    import gphoto2 as gp
+    import gphoto2cffi as gp
 
     # List all attached cameras that are supported
     cams = gp.list_cameras()


### PR DESCRIPTION
import should be `gphoto2cffi` instead of `gphoto2`.  Personally I prefer the latter instead of having that extra `cffi` on there, but the example should stick with how the library current works.