### PR TITLE
24.toggle debugging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,10 @@ offering access to most of the library's features.
     # Set a configuration value
     my_cam.config['capturesettings']['imagequality'].set("JPEG Fine")
 
+    # Turn on logging from gphoto2
+    from gphoto2cffi.backend import lib
+    lib.enable_logging = True
+
 Python 2.7 and 3.4 or newer (CPython and PyPy) are supported.
 
 .. _libgphoto2: http://www.gphoto.org/proj/libgphoto2/


### PR DESCRIPTION
Addressing #24, the programmer can now toggle logging on and off.  I did this without using statics.  Instead I created a wrapper function (inside of `__init__`) that will check if `self.enable_logging` is `True` or `False`.  And dependent upon that, it will actually log the message.

Also it bumps up the version number to 0.4.2.  If this looks good, please do a push to PyPi.