### PR TITLE
26.memory leaks

### DIFF
--- a/gphoto2cffi/gphoto2.py
+++ b/gphoto2cffi/gphoto2.py
@@ -558,6 +558,7 @@ class Camera(object):
 
         # pre-Allocate some more dynamic memory to be used for preview capture
         self.__camfile_p = ffi.new("CameraFile**")
+        lib.gp_file_new(self.__camfile_p)
         self.__data_p = ffi.new("char**")
         self.__length_p = ffi.new("unsigned long*")
 
@@ -765,7 +766,6 @@ class Camera(object):
         :return:    The preview image as a bytestring
         :rtype:     bytes
         """
-        lib.gp_file_new(self.__camfile_p)
         lib.gp_camera_capture_preview(self._cam, self.__camfile_p[0], self._ctx)
         lib.gp_file_get_data_and_size(self.__camfile_p[0], self.__data_p, self.__length_p)
         return ffi.buffer(self.__data_p[0], self.__length_p[0])[:]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ access to most of the library's features.
 
 setup(
     name='gphoto2-cffi',
-    version="0.4.1",
+    version="0.4.2",
     description=("libgphoto2 bindings with an interface that strives to be "
                  "idiomatic"),
     long_description=description_long,


### PR DESCRIPTION
this does solve the memory leaks for `capture()` completely, that's been a little difficult to track down the full culprit, but this does improve them just a tiny bit.  I suspect something might be happening with the `ffi.cast()` calls as well.  There could also be something in CFFI itself too.

I also included fixes for `get_preview()`.  I removed it's `@exit_after` decorator and added a new `exit()` method that the programmer can call instead to get out of the preview mode.

Version number was also bumped to `0.4.2`