### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,20 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit -r . || true
+      - run: black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: mypy --ignore-missing-imports . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       - run: black --check . || true
-      - run: codespell --ignore-words-list="struc" --quiet-level=2 || true  # --skip=""
+      - run: codespell --ignore-words-list="struc" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       - run: black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --ignore-words-list="struc" --quiet-level=2 || true  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+
 import sys
 
 sys.path.insert(0, '../')
@@ -13,7 +15,7 @@ class Mock(object):
 
     @classmethod
     def __getattr__(cls, name):
-        print "Getting mock: ", name
+        print("Getting mock: ", name)
         if name in ('__file__', '__path__'):
             return '/dev/null'
         # Special case for CFFI

--- a/gphoto2cffi/gphoto2.py
+++ b/gphoto2cffi/gphoto2.py
@@ -546,7 +546,7 @@ class Camera(object):
     def __init__(self, bus=None, device=None, lazy=False, _abilities=None):
         self._logger = logging.getLogger()
 
-        # NOTE: It is not strictly neccessary to create a context for every
+        # NOTE: It is not strictly necessary to create a context for every
         #       device, however it is significantly (>500ms) faster when
         #       actions are to be performed simultaneously.
         self._ctx = lib.gp_context_new()
@@ -809,7 +809,7 @@ class Camera(object):
 
     def _wait_for_event(self, event_type=None, duration=0):
         if event_type is None and not duration:
-            raise ValueError("Please specifiy either `event_type` or "
+            raise ValueError("Please specify either `event_type` or "
                              "`duration!`")
         start_time = time.time()
         self.__event_data_p[0] = ffi.NULL


### PR DESCRIPTION
Output: https://github.com/cclauss/gphoto2-cffi/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.